### PR TITLE
Make toast announce, most of the time.

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -15,12 +15,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <style>
     :host {
       display: inline-block;
+      position: fixed;
+
       background: #323232;
       color: #f1f1f1;
       min-height: 48px;
       min-width: 288px;
       padding: 16px 24px 12px;
-      position: fixed;
       box-sizing: border-box;
       box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
       border-radius: 2px;
@@ -28,7 +29,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       left: 12px;
       font-size: 14px;
       cursor: default;
-      transition-duration: 300ms;
+
+      -webkit-transition: visibility 0.3s, -webkit-transform 0.3s;
+      transition: visibility 0.3s, transform 0.3s;
+
+      -webkit-transform: translateY(100px);
+      transform: translateY(100px);
+
+      visibility: hidden;
     }
 
     :host(.capsule) {
@@ -42,18 +50,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       min-width: 0;
       border-radius: 0;
     }
-    :host(.paper-toast-closed) {
-      visibility: hidden;
-      transition: visibility 300ms, transform 300ms;
-      transform: translateY(100px);
-    }
-    :host(.paper-toast-openend){
-      transition: visibility, transform, 300ms;
-      transform: translateY(-100px);
+
+    :host(.paper-toast-open){
+      visibility: visible;
+
+      -webkit-transform: translateY(0px);
+      transform: translateY(0px);
     }
   </style>
   <template>
-    <span>{{text}}</span>
+    <span id="label" role="alert" aria-live="assertive">{{text}}</span>
     <content></content>
   </template>
 </dom-module>
@@ -64,13 +70,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     is: 'paper-toast',
 
     properties: {
-      opened: {
-        observer: 'openChanged',
-        type: Boolean,
-        notify: true,
-        value: false
-      },
-
       /**
        * The duration in milliseconds to show the toast.
        */
@@ -85,39 +84,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       text: {
         type: String,
         value: ""
+      },
+
+      visible: {
+        type: Boolean,
+        readOnly: true,
+        value: false,
+        observer: '_visibleChanged'
       }
     },
 
-    /**
-     * Hide the toast
-     * @return {[type]} [description]
-     */
-    hide: function() {
-      this.opened = false;
+    hostAttributes: {
+      role: 'alert',
+      'aria-live': 'assertive'
     },
 
-    _toggleClasses: function(visible) {
-      this.toggleClass('paper-toast-closed', !visible);
-      this.toggleClass('paper-toast-open', visible);
-    },
-
-    openChanged: function() {
-      if (this.opened) {
-        this.show();
-      } else {
-        if (PaperToast.currentToast === this) {
-          PaperToast.currentToast = null;
-        }
-        this._toggleClasses(false);
-      }
-    },
-
-    /**
-     * Toggle the opened state of the toast.
-     * @method toggle
-     */
-    toggle: function() {
-      this.opened = !this.opened;
+    ready: function() {
+      this.async(function() {
+        this.hide();
+      });
     },
 
     /**
@@ -125,15 +110,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @method show
      */
     show: function() {
-      this.opened = true;
-      if (PaperToast.currentToast && PaperToast.currentToast !== this) {
+      if (PaperToast.currentToast) {
         PaperToast.currentToast.hide();
       }
       PaperToast.currentToast = this;
-      this._toggleClasses(true);
-      this.debounce('dismissToast', this.hide, this.duration);
+      this._setVisible(true);
+      this._ariaAnnounce();
+      this.debounce('hide', this.hide, this.duration);
+    },
+
+    /**
+     * Hide the toast
+     * @return {[type]} [description]
+     */
+    hide: function() {
+      this.setAttribute('aria-live', 'off');
+      this.$.label.removeAttribute('role');
+      this.$.label.removeAttribute('aria-live');
+
+      this._setVisible(false);
+    },
+
+    /**
+     * Toggle the opened state of the toast.
+     * @method toggle
+     */
+    toggle: function() {
+      if (!this.visible) {
+        this.show();
+      } else {
+        this.hide();
+      }
+    },
+
+    _visibleChanged: function(visible) {
+      this.toggleClass('paper-toast-open', visible);
+    },
+
+    _ariaAnnounce: function() {
+      // Allow me to explain:
+      // http://www.paciellogroup.com/blog/2012/06/html5-accessibility-chops-aria-rolealert-browser-support/
+      var oldText = this.text;
+
+      this.setAttribute('aria-live', 'assertive');
+      this.$.label.setAttribute('role', 'alert');
+      this.$.label.setAttribute('aria-live', 'assertive');
+
+      this.text = '';
+      this.text = oldText;
+
+      this.$.label.style.visibility = 'hidden';
+      this.$.label.style.visibility = 'visible';
     }
 
   });
+
+  PaperToast.currentToast = null;
+
 })();
 </script>


### PR DESCRIPTION
Following examples at:

 - http://www.oaa-accessibility.org/examplep/alert1/
 - http://www.paciellogroup.com/blog/2012/06/html5-accessibility-chops-aria-rolealert-browser-support/

I have made the toast announce, but it is kind of flakey in VoiceOver. I would love any additional tips to make this work better. Current status:

 - Chrome: announces after first toast
 - Safari: announces after first toast
 - Firefox: never announces

/cc @robdodson @morethanreal @azakus 