### PR TITLE
Add a11y-announcer to toast.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
   "main": "paper-toast.html",
   "dependencies": {
     "paper-styles": "PolymerElements/paper-styles#^0.9.0",
-    "polymer": "Polymer/polymer#^0.9.0"
+    "polymer": "Polymer/polymer#^0.9.0",
+    "iron-a11y-announcer": "polymerelements/iron-a11y-announcer#^0.9.0"
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^0.9.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -48,8 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <paper-toast id="toast1" text="Your draft has been discarded."></paper-toast>
 
-  <paper-toast id="toast2" role="alert" text="Connection timed out. Showing limited messages.">
-    <span style="color: #eeff41;margin: 10px" onclick="console.log('RETRY')">Retry</span>
+  <paper-toast id="toast2" text="Connection timed out. Showing limited messages.">
+    <span role="button" tabindex="0" style="color: #eeff41;margin: 10px" onclick="console.log('RETRY')">Retry</span>
   </paper-toast>
 
 </body>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
 
 <!--
 `paper-toast` provides a subtle notification toast.
@@ -67,7 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </style>
   <template>
-    <span id="label" role="alert" aria-live="assertive">{{text}}</span>
+    <span id="label">{{text}}</span>
     <content></content>
   </template>
 </dom-module>
@@ -94,6 +95,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         value: ""
       },
 
+      /**
+       * True if the toast is currently visible.
+       */
       visible: {
         type: Boolean,
         readOnly: true,
@@ -102,9 +106,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
-    hostAttributes: {
-      role: 'alert',
-      'aria-live': 'assertive'
+    created: function() {
+      Polymer.IronA11yAnnouncer.requestAvailability();
     },
 
     ready: function() {
@@ -122,8 +125,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         PaperToast.currentToast.hide();
       }
       PaperToast.currentToast = this;
+      this.removeAttribute('aria-hidden');
       this._setVisible(true);
-      this._ariaAnnounce();
+      this.fire('iron-announce', {
+        text: this.text
+      });
       this.debounce('hide', this.hide, this.duration);
     },
 
@@ -132,10 +138,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {[type]} [description]
      */
     hide: function() {
-      this.setAttribute('aria-live', 'off');
-      this.$.label.removeAttribute('role');
-      this.$.label.removeAttribute('aria-live');
-
+      this.setAttribute('aria-hidden', 'true');
       this._setVisible(false);
     },
 
@@ -153,24 +156,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _visibleChanged: function(visible) {
       this.toggleClass('paper-toast-open', visible);
-    },
-
-    _ariaAnnounce: function() {
-      // Allow me to explain:
-      // http://www.paciellogroup.com/blog/2012/06/html5-accessibility-chops-aria-rolealert-browser-support/
-      var oldText = this.text;
-
-      this.setAttribute('aria-live', 'assertive');
-      this.$.label.setAttribute('role', 'alert');
-      this.$.label.setAttribute('aria-live', 'assertive');
-
-      this.text = '';
-      this.text = oldText;
-
-      this.$.label.style.visibility = 'hidden';
-      this.$.label.style.visibility = 'visible';
     }
-
   });
 
   PaperToast.currentToast = null;


### PR DESCRIPTION
Removes a bunch of stuff that is no longer needed due to presence of announcer.

Announcing is still really spotty, though :(

/cc @notwaldorf @morethanreal 