### PR TITLE
Remove unneeded import pulling roboto font

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,6 @@
   },
   "main": "paper-toast.html",
   "dependencies": {
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
     "iron-a11y-announcer": "polymerelements/iron-a11y-announcer#^1.0.0"
   },

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
 
 <!--


### PR DESCRIPTION
Importing typography.html results in importing font-robot which downloads
the corresponding google font.
Paper elements avoids importing anything from paper-style for that reason.
However, paper-toast imports typography.html, even if it doesn't use any of
the mixins available there.

I didn't readd this import in the demo page (even if it uses RobotoDraft) as
paper-ripple as well didn't import it. Note that iron-component-page does
depend on paper-styles which realize this import for both documentation and
demo page.

I'm happy to add the import to demo page if you feel this to be necessary.