### PR TITLE
Add custom color and prefix content to the toast

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../paper-toast.html">
   <link rel="import" href="../../paper-button/paper-button.html" >
+  <link rel="import" href="../../iron-icons/iron-icons.html" >
 
+  <style is="custom-style">
+    #toast3 {
+      --paper-toast-background: #FF0000;
+      --paper-toast-color: #FAFAF6;
+    }
+  </style>
   <style>
     html, body {
       height: 100%;
@@ -46,10 +53,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <paper-button raised onclick="document.querySelector('#toast2').show()">Get Messages</paper-button>
 
+  <paper-button raised onclick="document.querySelector('#toast3').show()">Get an error message</paper-button>
+
   <paper-toast id="toast1" text="Your draft has been discarded."></paper-toast>
 
   <paper-toast id="toast2" text="Connection timed out. Showing limited messages.">
     <span role="button" tabindex="0" style="color: #eeff41;margin: 10px" onclick="console.log('RETRY')">Retry</span>
+  </paper-toast>
+
+  <paper-toast id="toast3" text="Warning! This paper toast has color!">
+    <iron-icon prefix icon="error-outline"></iron-icon>
   </paper-toast>
 
 </body>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -15,6 +15,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 `paper-toast` provides a subtle notification toast.
 
+  <paper-toast text="Toast text"></paper-toast>
+
+### Toast message
+
+It can also include custom prefix or suffix elements, which are displayed
+before or after the toast text itself. In order for an element to be
+considered as a prefix, it must have the `prefix` attribute (`suffix`
+will be used if not specified).
+
+  `<paper-toast text="Toast text">
+    <iron-icon prefix icon="cloud-upload"></iron-icon>
+  </paper-toast>`
+
+### Styling
+
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-toast-background` | The background color of the paper-toat | `#323232`
+`--paper-toast-color` | The paper-toast color | `#f1f1f1`
+
 @group Paper Elements
 @element paper-toast
 @demo demo/index.html
@@ -26,8 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       display: inline-block;
       position: fixed;
 
-      background: #323232;
-      color: #f1f1f1;
+      background: var(--paper-toast-background, #323232);
+      color: var(--paper-toast-color, #f1f1f1);
       min-height: 48px;
       min-width: 288px;
       padding: 16px 24px 12px;
@@ -68,6 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </style>
   <template>
+    <content select="[prefix]"></content>
     <span id="label">{{text}}</span>
     <content></content>
   </template>


### PR DESCRIPTION
Add custom color and background color to the toast by setting --paper-toast-color and --paper-toast-background.

Add prefix content by adding the prefix attribute to the content inside the toast. By default suffix should be used to match the current toast behavior.

Added demo including both characteristics. 