### PR TITLE
Use iron overlay behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   "main": "paper-toast.html",
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#~1.0.9",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <paper-toast text="hi there!" opened></paper-toast>
+  <paper-toast class="fit-bottom" text="hi there!" opened></paper-toast>
 
   <paper-button raised onclick="document.querySelector('#toast1').show()">Discard Draft</paper-button>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
+  <paper-toast text="hi there!" opened></paper-toast>
+
   <paper-button raised onclick="document.querySelector('#toast1').show()">Discard Draft</paper-button>
 
   <paper-button raised onclick="document.querySelector('#toast2').show()">Get Messages</paper-button>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -28,8 +28,9 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
   <template>
     <style>
       :host {
-        display: inline-block;
+        display: block;
         position: fixed;
+
         background: #323232;
         color: #f1f1f1;
         min-height: 48px;
@@ -38,15 +39,18 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
         box-sizing: border-box;
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
         border-radius: 2px;
-        bottom: 12px;
-        left: 12px;
+        left: 0;
+        margin: 12px;
         font-size: 14px;
         cursor: default;
-        -webkit-transition: visibility 0.3s, -webkit-transform 0.3s;
-        transition: visibility 0.3s, transform 0.3s;
-        -webkit-transform: translateY(100px);
-        transform: translateY(100px);
+        -webkit-transition: visibility 0.3s, -webkit-transform 0.3s, opacity 0.3s;
+        transition: visibility 0.3s, transform 0.3s, opacity 0.3s;
+
         visibility: hidden;
+        bottom: -100px;
+        opacity: 0;
+        -webkit-transform: translateY(0px);
+        transform: translateY(0px);
       }
 
       :host(.capsule) {
@@ -54,17 +58,17 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
       }
 
       :host(.fit-bottom) {
-        bottom: 0;
-        left: 0;
         width: 100%;
         min-width: 0;
         border-radius: 0;
+        margin: 0;
       }
 
       :host(.paper-toast-open) {
         visibility: visible;
-        -webkit-transform: translateY(0px);
-        transform: translateY(0px);
+        opacity: 1;
+        -webkit-transform: translateY(-100px);
+        transform: translateY(-100px);
       }
     </style>
 
@@ -167,10 +171,15 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
           this.classList.remove('paper-toast-open');
         },
 
-        _onIronResize: function() {
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         * iron-fit-behavior will set the inline style position: static, which
+         * causes the toast to be rendered incorrectly when opened by default.
+         */
+        _onIronResize: function(){
           Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
           if (this.opened) {
-            // override the inline `static` setup by iron-fit-behavior since we need position: `fixed` for correct display
+            // Make sure there is no inline style for position.
             this.style.position = '';
           }
         }

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
+<link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../paper-styles/typography.html">
 
 <!--
@@ -29,7 +30,6 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
       :host {
         display: inline-block;
         position: fixed;
-
         background: #323232;
         color: #f1f1f1;
         min-height: 48px;
@@ -42,13 +42,10 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
         left: 12px;
         font-size: 14px;
         cursor: default;
-
-          -webkit-transition: visibility 0.3s, -webkit-transform 0.3s;
+        -webkit-transition: visibility 0.3s, -webkit-transform 0.3s;
         transition: visibility 0.3s, transform 0.3s;
-
-          -webkit-transform: translateY(100px);
+        -webkit-transform: translateY(100px);
         transform: translateY(100px);
-
         visibility: hidden;
       }
 
@@ -64,10 +61,9 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
         border-radius: 0;
       }
 
-      :host(.paper-toast-open){
+      :host(.paper-toast-open) {
         visibility: visible;
-
-          -webkit-transform: translateY(0px);
+        -webkit-transform: translateY(0px);
         transform: translateY(0px);
       }
     </style>
@@ -80,6 +76,10 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
     (function() {
       var PaperToast = Polymer({
         is: 'paper-toast',
+
+        behaviors: [
+          Polymer.IronOverlayBehavior
+        ],
 
         properties: {
           /**
@@ -95,25 +95,25 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
            */
           text: {
             type: String,
-            value: ""
+            value: ''
           },
 
           /**
-           * True if the toast is currently visible.
+           * Set to false to enable closing of the toast by clicking outside it.
            */
-          visible: {
+          noCancelOnOutsideClick: {
             type: Boolean,
-            readOnly: true,
-            observer: '_visibleChanged'
-          }
+            value: true
+          },
+        },
+
+        get visible() {
+          console.warn('`visible` is deprecated, use `opened` instead');
+          return this.opened;
         },
 
         created: function() {
           Polymer.IronA11yAnnouncer.requestAvailability();
-        },
-
-        attached: function() {
-          this.hide();
         },
 
         /**
@@ -121,50 +121,60 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
          * @method show
          */
         show: function() {
-          if (PaperToast.currentToast) {
-            PaperToast.currentToast.hide();
-          }
-          PaperToast.currentToast = this;
-          this.removeAttribute('aria-hidden');
-          this._setVisible(true);
-          this.fire('iron-announce', {
-            text: this.text
-          });
-          // auto-close if duration is a positive finite number
-          if (this.duration > 0 && this.duration !== Infinity) {
-            this.debounce('hide', this.hide, this.duration);
-          }
+          this.open();
         },
 
         /**
          * Hide the toast
          */
         hide: function() {
-          this.setAttribute('aria-hidden', 'true');
-          this._setVisible(false);
-          if (PaperToast.currentToast === this) {
-            PaperToast.currentToast = null;
-          }
+          this.close();
         },
 
         /**
-         * Toggle the opened state of the toast.
-         * @method toggle
+         * Overridden from `IronOverlayBehavior`.
+         * Called when the value of `opened` changes.
          */
-        toggle: function() {
-          if (!this.visible) {
-            this.show();
-          } else {
-            this.hide();
+        _openedChanged: function() {
+          if (this.opened) {
+            if (PaperToast.currentToast && PaperToast.currentToast !== this) {
+              PaperToast.currentToast.close();
+            }
+            PaperToast.currentToast = this;
+            this.fire('iron-announce', {
+              text: this.text
+            });
+            // auto-close if duration is a positive finite number
+            if (this.duration > 0 && this.duration !== Infinity) {
+              this.debounce('close', this.close, this.duration);
+            }
+          } else if (PaperToast.currentToast === this) {
+            PaperToast.currentToast = null;
           }
+          Polymer.IronOverlayBehaviorImpl._openedChanged.apply(this, arguments);
         },
 
-        _visibleChanged: function(visible) {
-          this.toggleClass('paper-toast-open', visible);
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         */
+        _renderOpened: function() {
+          this.classList.add('paper-toast-open');
+        },
+        /**
+         * Overridden from `IronOverlayBehavior`.
+         */
+        _renderClosed: function() {
+          this.classList.remove('paper-toast-open');
+        },
+
+        _onIronResize: function() {
+          Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
+          if (this.opened) {
+            // override the inline `static` setup by iron-fit-behavior since we need position: `fixed` for correct display
+            this.style.position = '';
+          }
         }
       });
-
-      PaperToast.currentToast = null;
     })();
   </script>
 </dom-module>

--- a/test/basic.html
+++ b/test/basic.html
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="show">
       <template>
-        <paper-toast></paper-toast>
+        <paper-toast opened></paper-toast>
       </template>
     </test-fixture>
 
@@ -43,21 +43,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('is hidden', function() {
           toast = fixture('basic');
-          assert.isFalse(toast.visible, '`visible` is false');
-          assert.strictEqual(toast.getAttribute('aria-hidden'), 'true', '`aria-hidden` attribute is set to `true`');
+          assert.isFalse(toast.opened, '`opened` is false');
         });
 
         test('is visible', function() {
           toast = fixture('show');
-          toast.show();
-          assert.isTrue(toast.visible, '`visible` is true');
-          assert.isFalse(toast.hasAttribute('aria-hidden'), '`aria-hidden` attribute is not set');
+          assert.isTrue(toast.opened, '`opened` is true');
         });
 
-        test('show() will update `visible`', function() {
+        test('show() will update `opened`', function() {
           toast = fixture('basic');
           toast.show();
-          assert.isTrue(toast.visible, '`visible` is true');
+          assert.isTrue(toast.opened, '`opened` is true');
         });
 
         test('show() will auto-close toast after `duration` milliseconds', function(done) {
@@ -67,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           toast.show();
           assert.isTrue(debounceSpy.called, '`debounce` was called');
           setTimeout(function(){
-            assert.isFalse(toast.visible, '`visible` is false');
+            assert.isFalse(toast.opened, '`opened` is false');
             done();
           }, 12);
         });
@@ -100,13 +97,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('there is only 1 toast opened', function() {
           var toast1 = fixture('basic');
           var toast2 = fixture('show');
-          toast2.show();
-          toast1.show();
-          assert.isTrue(toast1.visible, 'toast1 is visible');
-          assert.isFalse(toast2.visible, 'toast2 is not visible');
-          toast2.show();
-          assert.isFalse(toast1.visible, 'toast1 is now not visible');
-          assert.isTrue(toast2.visible, 'toast2 is now visible');
+          toast2.open();
+          toast1.open();
+          assert.isTrue(toast1.opened, 'toast1 is opened');
+          assert.isFalse(toast2.opened, 'toast2 is not opened');
+          toast2.open();
+          assert.isFalse(toast1.opened, 'toast1 is now not opened');
+          assert.isTrue(toast2.opened, 'toast2 is now opened');
         });
 
       });


### PR DESCRIPTION
Fixes #10, #13, #14, #19, #20 by providing ways to listen for changes on `opened` property.
Fixes #11 by making `toast` style hidden by default.
Fixes #17 by updating demo page with a `toast` that has `fit-bottom` class.
Also, using IronOverlayBehavior helps solving issues related to `z-index`