### PR TITLE
close toast via swipe

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#~1.0.9",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#~1.1.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,17 +42,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <paper-toast class="fit-bottom" text="hi there!" opened></paper-toast>
+  <paper-toast class="fit-bottom" text="Swipe to hide this toast." opened duration="0"></paper-toast>
 
-  <paper-button raised onclick="document.querySelector('#toast1').show()">Discard Draft</paper-button>
+  <paper-button raised onclick="openToast('#toast1')">Discard Draft</paper-button>
 
-  <paper-button raised onclick="document.querySelector('#toast2').show()">Get Messages</paper-button>
+  <paper-button raised onclick="openToast('#toast2')">Get Messages</paper-button>
 
   <paper-toast id="toast1" text="Your draft has been discarded."></paper-toast>
 
-  <paper-toast id="toast2" text="Connection timed out. Showing limited messages." duration="0" onclick="this.hide()">
-    <span role="button" tabindex="0" style="color: #eeff41;margin: 10px" onclick="console.log('RETRY')">Retry</span>
+  <paper-toast id="toast2" text="Connection timed out. Showing limited messages.">
+    <span role="button" tabindex="0" style="color: #eeff41;margin: 10px" onclick="closeToast('#toast2')">Retry</span>
   </paper-toast>
+
+  <script>
+    function openToast(toastSelector) {
+      console.log(toastSelector + ' opened');
+      document.querySelector(toastSelector).show();
+    }
+
+    function closeToast(toastSelector) {
+      console.log(toastSelector + ' closed');
+      document.querySelector(toastSelector).hide();
+    }
+  </script>
 
 </body>
 </html>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -43,14 +43,22 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
         margin: 12px;
         font-size: 14px;
         cursor: default;
-        -webkit-transition: visibility 0.3s, -webkit-transform 0.3s, opacity 0.3s;
-        transition: visibility 0.3s, transform 0.3s, opacity 0.3s;
+        -webkit-transition: -webkit-transform 0.3s, opacity 0.3s;
+        transition: transform 0.3s, opacity 0.3s;
 
-        visibility: hidden;
         bottom: -100px;
         opacity: 0;
         -webkit-transform: translateY(0px);
         transform: translateY(0px);
+      }
+
+      :host(.dragging) {
+        -webkit-transition: none;
+        transition: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
 
       :host(.capsule) {
@@ -65,7 +73,6 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
       }
 
       :host(.paper-toast-open) {
-        visibility: visible;
         opacity: 1;
         -webkit-transform: translateY(-100px);
         transform: translateY(-100px);
@@ -109,11 +116,28 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
             type: Boolean,
             value: true
           },
+
+          /**
+           * Set to true to disable swiping on the toast.
+           */
+          swipeDisabled: {
+            type: Boolean
+          },
+        },
+
+        listeners: {
+          track: '_track',
+          transitionend: '_transitionEnd'
         },
 
         get visible() {
           console.warn('`visible` is deprecated, use `opened` instead');
           return this.opened;
+        },
+
+        get _canAutoClose() {
+          // can auto-close if duration is a positive finite number
+          return this.opened && this.duration > 0 && this.duration !== Infinity;
         },
 
         created: function() {
@@ -140,6 +164,7 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
          * Called when the value of `opened` changes.
          */
         _openedChanged: function() {
+          this.cancelDebouncer('close');
           if (this.opened) {
             if (PaperToast.currentToast && PaperToast.currentToast !== this) {
               PaperToast.currentToast.close();
@@ -148,8 +173,8 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
             this.fire('iron-announce', {
               text: this.text
             });
-            // auto-close if duration is a positive finite number
-            if (this.duration > 0 && this.duration !== Infinity) {
+
+            if (this._canAutoClose) {
               this.debounce('close', this.close, this.duration);
             }
           } else if (PaperToast.currentToast === this) {
@@ -164,6 +189,7 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
         _renderOpened: function() {
           this.classList.add('paper-toast-open');
         },
+
         /**
          * Overridden from `IronOverlayBehavior`.
          */
@@ -176,12 +202,58 @@ Material design: [Snackbards & toasts](https://www.google.com/design/spec/compon
          * iron-fit-behavior will set the inline style position: static, which
          * causes the toast to be rendered incorrectly when opened by default.
          */
-        _onIronResize: function(){
+        _onIronResize: function() {
           Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
           if (this.opened) {
             // Make sure there is no inline style for position.
             this.style.position = '';
           }
+        },
+
+        /**
+         * _track handles swipe behavior.
+         * Opacity will be `1` for horizontal movement that is less than 20px.
+         * Toast will be closed if horizontal movement is >= 50px.
+         */
+        _track: function(e) {
+          if (this.swipeDisabled || !this.opened) {
+            return;
+          }
+          var dx = e.detail.dx;
+          // Values between [0.1, 1.0], will start fading after 20px of movement.
+          var opacity = Math.min(1.0, Math.max(0.1, (120 - Math.abs(dx)) / 100));
+          if (e.detail.state === 'start') {
+            this.toggleClass('dragging', true);
+            // Disable auto-close during swiping, will be triggered again
+            // on track end if necessary.
+            this.cancelDebouncer('close');
+          } else if (e.detail.state === 'end') {
+            this.toggleClass('dragging', false);
+            // close if distance is at least 50px
+            if (Math.abs(dx) >= 50) {
+              dx *= 2;
+              // Fade to transparent since we are closing.
+              opacity = 0;
+              // This will set opened, and toggle the right class.
+              this.close();
+            } else {
+              dx = 0;
+              opacity = '';
+              if (this._canAutoClose) {
+                this.debounce('close', this.close, this.duration);
+              }
+            }
+          }
+          this.transform(dx === 0 ? '' : 'translate3d('+ dx + 'px, -100px, 0)', this);
+          this.style.opacity = opacity;
+        },
+
+        /**
+         * Used to reset swipe inline styles in favor of class styles.
+         */
+        _transitionEnd: function () {
+          this.transform('', this);
+          this.style.opacity = '';
         }
       });
     })();

--- a/test/basic.html
+++ b/test/basic.html
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
     <link rel="import" href="../paper-toast.html">
 
@@ -104,6 +105,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           toast2.open();
           assert.isFalse(toast1.opened, 'toast1 is now not opened');
           assert.isTrue(toast2.opened, 'toast2 is now opened');
+        });
+
+        suite('swipe to close', function(){
+          setup(function(){
+            toast = fixture('show');
+          });
+
+          test('does not swipe when not opened', function() {
+            toast = fixture('basic');
+            MockInteractions.track(toast, 100, 0);
+            assert.isFalse(toast.opened);
+          });
+
+          test('cancels previous auto-close during swipe', function() {
+            var spy = sinon.spy(toast, 'cancelDebouncer');
+            MockInteractions.track(toast, 100, 0);
+            assert.isTrue(spy.called);
+          });
+
+          test('postpones auto-close if swipe does not trigger the close', function() {
+            toast = fixture('basic');
+            // This will trigger the auto-close.
+            toast.open();
+            // This will be called if auto-close is debounced again
+            var spy = sinon.spy(toast, 'debounce');
+            // swipe of 6px won't close the toast
+            MockInteractions.track(toast, 10, 0);
+            assert.isTrue(spy.called);
+          });
+
+          test('does not swipe when swipeDisabled is true', function() {
+            toast.swipeDisabled = true;
+            MockInteractions.track(toast, 100, 0);
+            assert.isTrue(toast.opened);
+          });
+
+          test('does not close if translation is between (-50px, 50px)', function() {
+            MockInteractions.track(toast, -49, 0);
+            assert.isTrue(toast.opened);
+            MockInteractions.track(toast, -10, 0);
+            assert.isTrue(toast.opened);
+            MockInteractions.track(toast, 10, 0);
+            assert.isTrue(toast.opened);
+            MockInteractions.track(toast, 49, 0);
+            assert.isTrue(toast.opened);
+          });
+
+          test('closes if translation is 50px (or more)', function() {
+            MockInteractions.track(toast, 50, 0);
+            assert.isFalse(toast.opened);
+          });
+
+          test('closes if translation is -50px (or less)', function() {
+            MockInteractions.track(toast, -50, 0);
+            assert.isFalse(toast.opened);
+          });
         });
 
       });


### PR DESCRIPTION
Fixes #6 by allowing to swipe the toast off the screen.
Added `swipeDisabled` property.
- auto-close won't be triggered during swiping
- `paper-toast` is closed if horizontal movement is `>= 50px` or `<= -50px`
- auto-close is triggered at the end of swipe if `paper-toast` is not swiped off screen

![paper-toast-swipe](https://cloud.githubusercontent.com/assets/6173664/11289865/c55a0df4-8ee5-11e5-8bd0-d60ffa91a143.gif)
