### PR TITLE
update jsdoc object notation

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -235,8 +235,7 @@ Custom property | Description | Default
          * Fired when `paper-toast` is opened.
          *
          * @event 'iron-announce'
-         * @param {Object} detail
-         * @param {String} detail.text The text that will be announced.
+         * @param {{text: string}} detail Contains text that will be announced.
          */
       });
     })();


### PR DESCRIPTION
This notation is needed since some jsdoc compilers will not accept the `.` in the param name.