### PR TITLE
showText()

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -177,6 +177,14 @@ Custom property | Description | Default
         },
 
         /**
+         * Set the toast's text and show.
+         */
+        showText: function(text) {
+            this.text = text;
+            this.open();
+        },
+
+        /**
          * Hide the toast. Same as `close()` from `IronOverlayBehavior`.
          */
         hide: function() {

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -177,7 +177,7 @@ Custom property | Description | Default
         },
 
         /**
-         * Set the toast's text and show.
+         * Shortcut to set text and show the toast with a single method.
          */
         showText: function(text) {
             this.text = text;


### PR DESCRIPTION
Add a method to both set the toast's `text` and fire its `show()` method in one step.

This allows the following to be combined into one line:

```javascript
myToast.text = "Hello World!";
myToast.show();
```
```javascript
myToast.showText("Hello World!");
```