### PR TITLE
remove import typography

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,11 +21,11 @@
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.0.9",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "paper-button": "PolymerElements/paper-button#^1.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,7 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <html>
+
 <head>
   <title>paper-toast</title>
 
@@ -19,63 +20,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../paper-toast.html">
-  <link rel="import" href="../../paper-button/paper-button.html" >
+  <link rel="import" href="../../paper-button/paper-button.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+  <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 
-  <style>
-    html, body {
-      height: 100%;
-    }
-
-    body {
-      overflow: hidden;
-      margin: 0;
-      font-family: RobotoDraft, 'Helvetica Neue', Helvetica, Arial;
-      -webkit-tap-highlight-color: rgba(0,0,0,0);
-      -webkit-touch-callout: none;
-    }
-
-    paper-button {
-      margin: 20px;
-    }
-  </style>
-
-  <style is="custom-style">
-    #toast3 {
-      --paper-toast-background-color: red;
-      --paper-toast-color: white;
-    }
-  </style>
+  <style is="custom-style" include="demo-pages-shared-styles"></style>
 
 </head>
-<body>
 
+<body unresolved class="centered">
+  <h3>Toast auto-closes after 3 seconds. Only one toast per time will be visible</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <paper-button raised onclick="toast0.open()">Default toast</paper-button>
+      <paper-button raised onclick="toast1.open()">With content</paper-button>
 
-  <paper-button raised onclick="openToast('#toast1')">Discard Draft</paper-button>
+      <paper-toast id="toast0" text="This toast auto-closes after 3 seconds"></paper-toast>
+      <paper-toast id="toast1" text="This toast auto-closes after 3 seconds">
+        <span role="button" tabindex="0" onclick="toast1.close()" style="color: #eeff41;margin: 10px">Close now!</span>
+      </paper-toast>
+    </template>
+  </demo-snippet>
 
-  <paper-button raised onclick="openToast('#toast2')">Get Messages</paper-button>
+  <h3>Toast does not auto-close when <code>duration</code> is negative, <code>0</code>, or <code>Infinity</code></h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <paper-button raised onclick="toast2.toggle()">Toggle toast</paper-button>
+      <paper-toast id="toast2" duration="0" text="This toast will stay opened until you close it, or open another toast."></paper-toast>
+    </template>
+  </demo-snippet>
 
-  <paper-button raised onclick="openToast('#toast3')">Get an error</paper-button>
+  <h3>Toast can be styled</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <style is="custom-style">
+        #toast3 {
+          --paper-toast-background-color: red;
+          --paper-toast-color: white;
+        }
+      </style>
+      <paper-button raised onclick="toast3.open()">With style</paper-button>
+      <paper-button raised onclick="toast4.open()">Fit bottom</paper-button>
 
-  <paper-toast id="toast0" class="fit-bottom" text="Hi there! This toast will stay opened until you open another toast." opened duration="0"></paper-toast>
-
-  <paper-toast id="toast1" text="Your draft has been discarded."></paper-toast>
-
-  <paper-toast id="toast2" text="Connection timed out. Showing limited messages.">
-    <span role="button" tabindex="0" style="color: #eeff41;margin: 10px" onclick="closeToast('#toast2')">Retry</span>
-  </paper-toast>
-
-  <paper-toast id="toast3" text="This paper toast has color!"></paper-toast>
-
-  <script>
-    function openToast(selector) {
-      console.log('opening ' + selector);
-      document.querySelector(selector).open();
-    }
-    function closeToast(selector) {
-      console.log('closing ' + selector);
-      document.querySelector(selector).close();
-    }
-  </script>
-
+      <paper-toast id="toast3" text="This toast has color!"></paper-toast>
+      <paper-toast id="toast4" class="fit-bottom" text="This toast fits bottom"></paper-toast>
+    </template>
+  </demo-snippet>
 </body>
+
 </html>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -11,7 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
-<link rel="import" href="../paper-styles/typography.html">
 
 <!--
 Material design: [Snackbards & toasts](https://www.google.com/design/spec/components/snackbars-toasts.html)
@@ -54,6 +53,9 @@ Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-toast-background-color` | The paper-toast background-color | `#323232`
 `--paper-toast-color` | The paper-toast color | `#f1f1f1`
+
+This element applies the mixin `--paper-font-common-base` but does not import `paper-styles/typography.html`.
+In order to apply the `Roboto` font to this element, make sure you've imported `paper-styles/typography.html`.
 
 @group Paper Elements
 @element paper-toast


### PR DESCRIPTION
Removed the import of `typography.html`, updated the demo page to use `demo-snippet`
![paper-toast-doc](https://cloud.githubusercontent.com/assets/6173664/12520160/c8ad81ea-c0f7-11e5-8c2c-b584c9b0ecd5.gif)


Finalization of https://github.com/PolymerElements/paper-toast/pull/45