### PR TITLE
update left/bottom according to fitInto

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -66,8 +66,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </style>
 
       <paper-button raised onclick="toast2.open()">Styled toast</paper-button>
-      
+
       <paper-toast id="toast2" class="fit-bottom" text="This toast is red and fits bottom!"></paper-toast>
+    </template>
+  </demo-snippet>
+
+  <h3>Toast can fit into any element</h3>
+  <demo-snippet class="centered-demo">
+    <template>
+      <style>
+        #container {
+          padding: 100px;
+          border: 1px solid gray;
+        }
+      </style>
+      <div id="container">
+        <paper-button raised onclick="toast3.open()">Open toast</paper-button>
+      </div>
+      <paper-toast id="toast3" class="fit-bottom" text="This toast fits into the container."></paper-toast>
+
+      <script>
+        toast3.fitInto = container;
+      </script>
+
     </template>
   </demo-snippet>
 </body>

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -82,9 +82,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         margin: 12px;
         font-size: 14px;
         cursor: default;
-        -webkit-transition: visibility 0.3s, -webkit-transform 0.3s, opacity 0.3s;
-        transition: visibility 0.3s, transform 0.3s, opacity 0.3s;
-        visibility: hidden;
+        -webkit-transition: -webkit-transform 0.3s, opacity 0.3s;
+        transition: transform 0.3s, opacity 0.3s;
         opacity: 0;
         -webkit-transform: translateY(100px);
         transform: translateY(100px);
@@ -103,7 +102,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host(.paper-toast-open) {
-        visibility: visible;
         opacity: 1;
         -webkit-transform: translateY(0px);
         transform: translateY(0px);
@@ -211,12 +209,25 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         },
 
         /**
+         * Overridden from `IronFitBehavior`.
+         * Positions the toast at the bottom left of fitInto.
+         */
+        center: function () {
+          if (this.fitInto === window) {
+            this.style.bottom = this.style.left = '';
+          } else {
+            var rect = this.fitInto.getBoundingClientRect();
+            this.style.left = rect.left + 'px';
+            this.style.bottom = (window.innerHeight - rect.bottom) + 'px';
+          }
+        },
+
+        /**
          * Called on transitions of the toast, indicating a finished animation
-         *
          * @private
          */
         __onTransitionEnd: function(e) {
-          // there are at least three different transitions that are happening when opening and
+          // there are different transitions that are happening when opening and
           // closing the toast. The last one so far is for `opacity`.
           // This marks the end of the transition, so we check for this to determine if this
           // is the correct event.

--- a/test/basic.html
+++ b/test/basic.html
@@ -21,6 +21,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../paper-toast.html">
 
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
 </head>
 
 <body>
@@ -37,7 +43,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="contained">
+    <template>
+      <paper-toast class="fit-bottom"></paper-toast>
+      <div style="margin: 50px; width: 100px; height: 100px; background-color: orange;"></div>
+    </template>
+  </test-fixture>
+
   <script>
+
     suite('basic', function() {
 
       var toast;
@@ -73,19 +87,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         }, 12);
       });
-      
-      test('toast fires closed event', function(done) {
+
+      test('toast fires opened event', function(done) {
         toast = fixture('show');
-        toast.addEventListener('iron-overlay-opened', toast.close.bind(toast));
-        toast.addEventListener('iron-overlay-closed', function() {
+        toast.addEventListener('iron-overlay-opened', function() {
           done();
         });
       });
 
-      test('toast fires opened event', function(done) {
-        toast = fixture('show');
-          toast.addEventListener('iron-overlay-opened', function() {
-            done();
+      test('toast fires closed event', function(done) {
+        toast = fixture('basic');
+        toast.show({duration: 350});
+        toast.addEventListener('iron-overlay-closed', function() {
+          done();
         });
       });
 
@@ -173,6 +187,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           }, 10);
         }, 5);
+      });
+
+      test('toast is positioned according at the bottom left of its fitInto', function() {
+        var f = fixture('contained');
+        var toast = f[0];
+        var container = f[1];
+        toast.fitInto = container;
+        toast.center();
+        var style = getComputedStyle(toast);
+        assert.equal(style.left, '50px', 'left');
+        // Should be 150px from top, (100px of height + 50px of margin-top)
+        // aka window height - 150 from bottom.
+        assert.equal(style.bottom, (window.innerHeight - 150) + 'px', 'bottom');
       });
 
       suite('a11y', function() {


### PR DESCRIPTION
Fixes #59 by updating `left/bottom` css properties according to `fitInto` position.
Overriding the `center()` method allows the Polymer user to call `center()` every time the `fitInto` element changes its position.
Also fixes broken tests on safari. This was caused by the fact that animations are not triggered on  safari, hence `iron-overlay-opened` and `iron-overlay-closed` weren't triggered. This was caused by the 3 transition properties `paper-toast` was setting, in particular `visibility` and `transform`. Since `iron-overlay-behavior` will set the `display: none` when `opened = false`, we don't need to set `visibility`.