### PR TITLE
Add support for parameters in the show() method

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -170,9 +170,23 @@ Custom property | Description | Default
         },
 
         /**
-         * Show the toast. Same as `open()` from `IronOverlayBehavior`.
+         * Show the toast. Without arguments, this is the same as `open()` from `IronOverlayBehavior`.
+         * @param {Object|string|undefined} properties Properties to be set before opening the toast.
+         * e.g. `toast.show('hello')` or `toast.show({text: 'hello', duration: 3000})`
          */
-        show: function() {
+        show: function(properties) {
+          if (typeof properties == 'string') {
+            properties = { text: properties };
+          }
+          for (var property in properties) {
+            if (property.indexOf('_') === 0) {
+              console.warn('The property "' + property + '" is private and was not set.');
+            } else if (property in this) {
+              this[property] = properties[property];
+            } else {
+              console.warn('The property "' + property + '" is not valid.');
+            }
+          }
           this.open();
         },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -74,6 +74,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 12);
       });
 
+      test('show() accepts valid properties', function() {
+        toast = fixture('basic');
+        toast.show({text: 'hello world', duration: 20});
+        assert.isTrue(toast.opened, '`opened` is true');
+        assert.equal(toast.text, 'hello world', '`text` is correct');
+        assert.equal(toast.duration, 20, '`duration` is correct');
+      });
+
+      test('show() does not accept invalid properties', function() {
+        toast = fixture('basic');
+        toast.show({foo: 'bar'});
+        assert.isUndefined(toast.foo, '`foo` is not a valid property and will not be set');
+        assert.isTrue(toast.opened, '`opened` is true');
+      });
+
+      test('show() does not accept private properties', function() {
+        toast = fixture('basic');
+        var temp = toast._manager;
+        toast.show({_manager: 'bar'});
+        assert.equal(toast._manager, temp, '`_manager` is a private property and will not be set');
+        assert.isTrue(toast.opened, '`opened` is true');
+      });
+
+      test('show() accepts a string argument as the text parameter', function() {
+        toast = fixture('basic');
+        toast.show('hello world 2');
+        assert.equal(toast.text, 'hello world 2', '`text is correct`');
+      });
+
       suite('disable auto-close', function() {
         var spy;
         setup(function() {


### PR DESCRIPTION
The show method will now accept an argument of either a single string,
which is used to set the text parameter of the toast, or an object,
whose properties are merged with the toast's existing properties.

This PR is suggested in #61.