### PR TITLE
#64 paper-toast does not fire closed events

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -152,7 +152,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
           noCancelOnOutsideClick: {
             type: Boolean,
             value: true
-          },
+          }
+        },
+
+        listeners: {
+          'transitionend': '__onTransitionEnd'
         },
 
         /**
@@ -190,6 +194,25 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
          */
         hide: function() {
           this.close();
+        },
+
+        /**
+         * Called on transitions of the toast, indicating a finished animation
+         *
+         * @private
+         */
+        __onTransitionEnd: function(e) {
+          // there are at least three different transitions that are happening when opening and
+          // closing the toast. The last one so far is for `opacity`.
+          // This marks the end of the transition, so we check for this to determine if this
+          // is the correct event.
+          if (e && e.target === this && e.propertyName === 'opacity') {
+            if (this.opened) {
+              this._finishRenderOpened();
+            } else {
+              this._finishRenderClosed();
+            }
+          }
         },
 
         /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -73,6 +73,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         }, 12);
       });
+      
+      test('toast fires closed event', function(done) {
+        toast = fixture('show');
+        toast.addEventListener('iron-overlay-opened', toast.close.bind(toast));
+        toast.addEventListener('iron-overlay-closed', function() {
+          done();
+        });
+      });
+
+      test('toast fires opened event', function(done) {
+        toast = fixture('show');
+          toast.addEventListener('iron-overlay-opened', function() {
+            done();
+        });
+      });
 
       suite('disable auto-close', function() {
         var spy;


### PR DESCRIPTION
#64 paper-toast does not fire closed events
Add call to Polymer.IronBehaviorImpl._renderClosed to the _renderClosed function so that the expected event is fired.