### PR TITLE
Add open-from-top class to open the toast from top

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -90,6 +90,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         @apply(--paper-font-common-base);
       }
 
+      :host(.open-from-top) {
+        bottom: inherit;
+        top:0;
+        -webkit-transform: translateY(-100px);
+        transform: translateY(-100px);
+      }
+
       :host(.capsule) {
         border-radius: 24px;
       }


### PR DESCRIPTION
The toast is sometime not visible while working with forms in ios phones. The keypad hides it. And we should give flexibility to open it from top.

Thanks