### PR TITLE
set noAutoFocus default value to true

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -150,6 +150,16 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
           noCancelOnOutsideClick: {
             type: Boolean,
             value: true
+          },
+
+          /**
+           * Overridden from `IronOverlayBehavior`.
+           * Set to true to disable auto-focusing the toast or child nodes with
+           * the `autofocus` attribute` when the overlay is opened.
+           */
+          noAutoFocus: {
+            type: Boolean,
+            value: true
           }
         },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -95,6 +95,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('toast does not get focused', function(done) {
+        toast = fixture('show');
+        var spy = sinon.spy(toast, 'focus');
+        assert.isTrue(toast.noAutoFocus, 'no-auto-focus is true');
+        toast.addEventListener('iron-overlay-opened', function() {
+          assert.isFalse(spy.called, 'toast is not focused');
+          done();
+        });
+      });
+
       test('toast fires closed event', function(done) {
         toast = fixture('basic');
         toast.show({duration: 350});


### PR DESCRIPTION
Fixes #3 by disabling the autofocus feature of `iron-overlay-behavior`, so that the toast won't try to steal the focus, allowing the tabbing to follow the natural appearance of the elements in the document.