### PR TITLE
use horizontalAlign and verticalAlign

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.0.9",
+    "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.1.0",
     "polymer": "Polymer/polymer#^1.5.0"
   },
   "devDependencies": {

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -77,8 +77,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         box-sizing: border-box;
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
         border-radius: 2px;
-        left: 0;
-        bottom: 0;
         margin: 12px;
         font-size: 14px;
         cursor: default;
@@ -125,6 +123,36 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         ],
 
         properties: {
+          /**
+           * The element to fit `this` into.
+           * Overridden from `Polymer.IronFitBehavior`.
+           */
+          fitInto: {
+            type: Object,
+            value: window,
+            observer: '_onFitIntoChanged'
+          },
+
+          /**
+           * The orientation against which to align the dropdown content
+           * horizontally relative to `positionTarget`.
+           * Overridden from `Polymer.IronFitBehavior`.
+           */
+          horizontalAlign: {
+            type: String,
+            value: 'left'
+          },
+
+          /**
+           * The orientation against which to align the dropdown content
+           * vertically relative to `positionTarget`.
+           * Overridden from `Polymer.IronFitBehavior`.
+           */
+          verticalAlign: {
+            type: String,
+            value: 'bottom'
+          },
+
           /**
            * The duration in milliseconds to show the toast.
            * Set to `0`, a negative number, or `Infinity`, to disable the
@@ -219,20 +247,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         },
 
         /**
-         * Overridden from `IronFitBehavior`.
-         * Positions the toast at the bottom left of fitInto.
-         */
-        center: function () {
-          if (this.fitInto === window) {
-            this.style.bottom = this.style.left = '';
-          } else {
-            var rect = this.fitInto.getBoundingClientRect();
-            this.style.left = rect.left + 'px';
-            this.style.bottom = (window.innerHeight - rect.bottom) + 'px';
-          }
-        },
-
-        /**
          * Called on transitions of the toast, indicating a finished animation
          * @private
          */
@@ -291,16 +305,10 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         },
 
         /**
-         * Overridden from `IronOverlayBehavior`.
-         * iron-fit-behavior will set the inline style position: static, which
-         * causes the toast to be rendered incorrectly when opened by default.
+         * @private
          */
-        _onIronResize: function() {
-          Polymer.IronOverlayBehaviorImpl._onIronResize.apply(this, arguments);
-          if (this.opened) {
-            // Make sure there is no inline style for position.
-            this.style.position = '';
-          }
+        _onFitIntoChanged: function(fitInto) {
+          this.positionTarget = fitInto;
         }
 
         /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -200,17 +200,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 5);
       });
 
-      test('toast is positioned according at the bottom left of its fitInto', function() {
+      test('toast is positioned according at the bottom left of its fitInto', function(done) {
         var f = fixture('contained');
         var toast = f[0];
         var container = f[1];
         toast.fitInto = container;
-        toast.center();
-        var style = getComputedStyle(toast);
-        assert.equal(style.left, '50px', 'left');
-        // Should be 150px from top, (100px of height + 50px of margin-top)
-        // aka window height - 150 from bottom.
-        assert.equal(style.bottom, (window.innerHeight - 150) + 'px', 'bottom');
+        toast.open();
+        // Wait for it to be opened, so it will be sized correctly.
+        toast.addEventListener('iron-overlay-opened', function() {
+          var rect = toast.getBoundingClientRect();
+          assert.equal(rect.left, 50, 'left ok');
+          // 150px from top, (100px of height + 50px of margin-top)
+          assert.equal(rect.bottom, 150, 'bottom');
+          done();
+        });
       });
 
       suite('a11y', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-toast/issues/67, as it exposes the new `verticalAlign` and `horizontalAlign` (inherited from `iron-fit-behavior v1.1.1`).
Fixes #73 in the sense that now we don't need to override all those things.