### PR TITLE
Spell correct 'snackbards' typo

### DIFF
--- a/paper-toast.html
+++ b/paper-toast.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 
 <!--
-Material design: [Snackbards & toasts](https://www.google.com/design/spec/components/snackbars-toasts.html)
+Material design: [Snackbars & toasts](https://www.google.com/design/spec/components/snackbars-toasts.html)
 
 `paper-toast` provides a subtle notification toast. Only one `paper-toast` will
 be visible on screen.


### PR DESCRIPTION
Fixes a small typo in the material design link.