### PR TITLE
allow-click-through

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "main": "paper-toast.html",
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#1 - 2",
-    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#click-through-property",
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^2.1.0",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#1 - 2",
     "polymer": "Polymer/polymer#1.9 - 2"
   },
@@ -36,7 +36,7 @@
     "1.x": {
       "dependencies": {
         "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
-        "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#click-through-property",
+        "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^2.1.0",
         "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.1.0",
         "polymer": "Polymer/polymer#^1.9"
       },

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "main": "paper-toast.html",
   "dependencies": {
     "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#1 - 2",
-    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#1 - 2",
+    "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#click-through-property",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#1 - 2",
     "polymer": "Polymer/polymer#1.9 - 2"
   },
@@ -28,7 +28,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "paper-button": "PolymerElements/paper-button#1 - 2",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0",
     "web-component-tester": "^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
@@ -36,7 +36,7 @@
     "1.x": {
       "dependencies": {
         "iron-a11y-announcer": "PolymerElements/iron-a11y-announcer#^1.0.0",
-        "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.0.9",
+        "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#click-through-property",
         "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.1.0",
         "polymer": "Polymer/polymer#^1.9"
       },

--- a/paper-toast.html
+++ b/paper-toast.html
@@ -190,6 +190,15 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
           noAutoFocus: {
             type: Boolean,
             value: true
+          },
+
+          /**
+           * Overridden from `IronOverlayBehavior`.
+           * Set to false to prevent outside clicks to reach overlays below the toast. 
+           */
+          allowClickThrough: {
+            type: Boolean,
+            value: true
           }
         },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,6 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
+  <link rel="import" href="test-overlay.html">
   <link rel="import" href="../paper-toast.html">
 
   <style>
@@ -50,6 +51,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div style="margin: 50px; width: 100px; height: 100px; background-color: orange;"></div>
     </template>
   </test-fixture>
+
+  <test-fixture id="multiple">
+    <template>
+      <test-overlay></test-overlay>
+      <paper-toast></paper-toast>
+    </template>
+  </test-fixture>
+
 
   <script>
 
@@ -214,6 +223,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(rect.bottom, 150, 'bottom');
           done();
         });
+      });
+
+      suite('allow-click-through', function() {
+        
+        var overlay;
+        
+        setup(function() {
+          var f = fixture('multiple');
+          overlay = f[0];
+          toast = f[1];
+        });
+
+        test('default value is true', function() {
+          assert.isTrue(toast.allowClickThrough);
+        });
+        
+
+        test('outside click handled by overlay below', function(done) {
+          overlay.open();
+          toast.show();
+          toast.addEventListener('iron-overlay-opened', function() {
+            document.body.click();
+            assert.isFalse(overlay.opened, 'overlay closed');
+            assert.isTrue(toast.opened, 'toast stays open');
+            done();
+          });
+        });
+
       });
 
       suite('a11y', function() {

--- a/test/test-overlay.html
+++ b/test/test-overlay.html
@@ -1,0 +1,20 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-overlay-behavior/iron-overlay-behavior.html">
+<script>
+  Polymer({
+    is: 'test-overlay',
+    behaviors: [
+      Polymer.IronOverlayBehavior
+    ]
+  });
+</script>


### PR DESCRIPTION
Set `allow-click-through` default to `true`, as toasts should allow overlays below it to handle outside click events.